### PR TITLE
fix: Fix job label

### DIFF
--- a/pkg/backend/kubeflow/labels.go
+++ b/pkg/backend/kubeflow/labels.go
@@ -23,11 +23,11 @@ import (
 )
 
 const (
-	labelTFJobName      = "tf_job_name"
+	labelTFJobName      = "tf-job-name"
 	tfReplicaTypeLabel  = "tf-replica-type"
 	tfReplicaIndexLabel = "tf-replica-index"
 
-	labelPyTorchJobName      = "pytorch_job_name"
+	labelPyTorchJobName      = "pytorch-job-name"
 	pytorchReplicaTypeLabel  = "pytorch-replica-type"
 	pytorchReplicaIndexLabel = "pytorch-replica-index"
 )


### PR DESCRIPTION
**What this PR does / why we need it**:

the hyphen in job name label has been changed to use underscore, so pods will never be found.

**Which issue(s) this PR is related to** *(optional, link to 3rd issue(s))*:

Fixes #79 

**Special notes for your reviewer**:

/cc @your-reviewer

**Release note**:

```release-note
NONE
```